### PR TITLE
Use tilde as shorthand for {cardname}

### DIFF
--- a/creator/index.html
+++ b/creator/index.html
@@ -217,7 +217,7 @@
 								<h5 class='margin-top'>Text Codes:</h5>
 								<div class='text-codes margin-bottom padding'>
 									<h5>Code</h5><h5>Result</h5>
-									<h5>{cardname}</h5><h5>Inserts the name of the card</h5>
+									<h5>{cardname}</h5><h5>Inserts the name of the card (or use a tilde: ~)</h5>
 									<h5>{-}</h5><h5>Inserts an em-dash</h5>
 									<h5>{i}</h5><h5>Italicizes text</h5>
 									<h5>{/i}</h5><h5>Removes italicization</h5>

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -891,7 +891,7 @@ function writeText(textObject, targetContext) {
 		rawText = params.get('copyright'); //so people using CC for custom card games without WotC's IP can customize their copyright info
 		if (rawText == 'none') { rawText = ''; }
 	}
-	if (rawText.toLowerCase().includes('{cardname}')) {
+	if (rawText.toLowerCase().includes('{cardname}' || '~')) {
 		rawText = rawText.replace(/{cardname}/ig, getCardName());
 	}
 	if (document.querySelector('#info-artist').value == '') {

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -892,7 +892,7 @@ function writeText(textObject, targetContext) {
 		if (rawText == 'none') { rawText = ''; }
 	}
 	if (rawText.toLowerCase().includes('{cardname}' || '~')) {
-		rawText = rawText.replace(/{cardname}/ig, getCardName());
+		rawText = rawText.replace(/{cardname}|~/ig, getCardName());
 	}
 	if (document.querySelector('#info-artist').value == '') {
 		rawText = rawText.replace('\uFFEE{elemidinfo-artist}', '');


### PR DESCRIPTION
Typing out curly braces is tedious, and unfriendly to arthritis/RSI.

MSE users may expect tilde to "just work" in the same way it does on MSE.

Even scryfall queries can be made using the traditional tilde: https://scryfall.com/docs/syntax