### PR TITLE
Add special case to imageURL for loading local images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,16 @@ http://localhost:4242/
 ### Important
 
 Be sure, that you are running Docker Desktop under Windows or Mac before you can run the make command.
+
+## Using Local Images
+
+If you're saving a lot of cards custom images you might hit the data limit for uploaded images (about 2MB).
+
+You can avoid this by putting the image files in the `local_art` directory of this repo. Then, when selecting the image in the Art tab of the card creator, instead of uploading the image you can type the file name in the "Via URL" field. This will use the image directly from the `local_art` directory instead of needing to store the whole image in the save file.
+
+For example if you add the file:
+`cardconjurer/local_art/my_art.jpg`
+
+You can load it in the "Via URL" box by typing:
+`my_art.jpg`
+then hitting enter.

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -2190,7 +2190,7 @@ function setRoundedCorners(value) {
 //Various loaders
 function imageURL(url, destination, otherParams) {
 	var imageurl = url;
-	// If an image URL does not have HTTP in it, assume it's a local file at the HTML root directory.
+	// If an image URL does not have HTTP in it, assume it's a local file in the repo local_art directory.
 	if (!url.includes('http')) {
 		imageurl = '/local_art/' + url;
 	} else if (params.get('noproxy') != '') {

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -2192,7 +2192,7 @@ function imageURL(url, destination, otherParams) {
 	var imageurl = url;
 	// If an image URL does not have HTTP in it, assume it's a local file at the HTML root directory.
 	if (!url.includes('http')) {
-		imageurl = '/' + url;
+		imageurl = '/local_art/' + url;
 	} else if (params.get('noproxy') != '') {
 		//CORS PROXY LINKS
 		//Previously: https://cors.bridged.cc/

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -2190,7 +2190,10 @@ function setRoundedCorners(value) {
 //Various loaders
 function imageURL(url, destination, otherParams) {
 	var imageurl = url;
-	if (params.get('noproxy') != '') {
+	// If an image URL does not have HTTP in it, assume it's a local file at the HTML root directory.
+	if (!url.includes('http')) {
+		imageurl = '/' + url;
+	} else if (params.get('noproxy') != '') {
 		//CORS PROXY LINKS
 		//Previously: https://cors.bridged.cc/
 		imageurl = 'https://api.codetabs.com/v1/proxy?quest=' + url;

--- a/local_art/.gitignore
+++ b/local_art/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Hi, not sure if you're planning on doing development or taking PRs, but here's a little change I found useful on the original site.

There's probably a better way to do this, but this was a hack I found useful for getting around the localcache limitations when I was working with a large set of cards with custom art I was making myself (see https://www.robopenguins.com/even-more-custom-mtg-cards/).

This is an alternative to needing to embed local images into the JSON or hosting them online.

Basically, if you go to the **Art** page in the card creator and instead of adding a URL type just the image file name (like `my_image.jpg`) this hack will use the URL to `/local_art/my_image.jpg`.

Then if you have the custom art you're using in the local_art directory of the repo, it will be loaded directly from the local server running Card Conjurer. 