### PR TITLE
Fix bug with ~ support for card name

### DIFF
--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -891,7 +891,7 @@ function writeText(textObject, targetContext) {
 		rawText = params.get('copyright'); //so people using CC for custom card games without WotC's IP can customize their copyright info
 		if (rawText == 'none') { rawText = ''; }
 	}
-	if (rawText.toLowerCase().includes('{cardname}' || '~')) {
+	if (rawText.toLowerCase().includes('{cardname}') || rawText.toLowerCase().includes('~')) {
 		rawText = rawText.replace(/{cardname}|~/ig, getCardName());
 	}
 	if (document.querySelector('#info-artist').value == '') {


### PR DESCRIPTION
The previous code would only support ~ if there was also an instance of {cardname} in the text.