### PR TITLE
Update CORS proxy to working site

### DIFF
--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -2196,7 +2196,7 @@ function imageURL(url, destination, otherParams) {
 	} else if (params.get('noproxy') != '') {
 		//CORS PROXY LINKS
 		//Previously: https://cors.bridged.cc/
-		imageurl = 'https://api.codetabs.com/v1/proxy?quest=' + url;
+		imageurl = 'https://corsproxy.io/?' + url;
 	}
 	destination(imageurl, otherParams);
 }


### PR DESCRIPTION
It seems that Codetabs no longer does the job properly, as I'm getting CORS errors as per a few days ago in my browser (Firefox 109.0.1 and 110.0 both tested across different machines) when trying to load art from MTGPics. I've hacked around in the console a little bit and it seems like corsproxy.io does properly work right now, which is why I've chosen it for this PR.