### PR TITLE
Improve Docker & fix local art bug

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,9 @@ dev/*
 /.idea
 /.git
 
+# volume mounts
+local_art
+
 # misc
 .DS_Store
 .env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ FROM nginx:1.21-alpine as prod
 EXPOSE 4242
 COPY . /usr/share/nginx/html/
 COPY app.conf /etc/nginx/nginx.conf
-

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ start:
 		--hostname 127.0.0.1 \
 		--publish 4242:4242 \
 		--name cardconjurer-client \
-		--volume ./:/usr/share/nginx/html/:ro \
+		--volume ./local_art/:/usr/share/nginx/html/local_art/:ro \
 		"cardconjurer-client"
 
 stop:

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,19 @@
+.PHONY: start stop
+
 start:
-	docker build -f Dockerfile --target "prod" . -t "cardconjurer-client" && docker run -dit -h 127.0.0.1 -p 4242:4242 "cardconjurer-client"
+	docker build \
+		--file Dockerfile \
+		--target "prod" \
+		--tag "cardconjurer-client" \
+		. && \
+	docker run \
+		--detach \
+		--hostname 127.0.0.1 \
+		--publish 4242:4242 \
+		--name cardconjurer-client \
+		--volume ./:/usr/share/nginx/html/:ro \
+		"cardconjurer-client"
+
+stop:
+	docker stop cardconjurer-client && \
+	docker rm cardconjurer-client

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Open your Browser with the following URL
 
 http://localhost:4242/
 
+When you're done making cards, run the following command to stop the application:
+
+```bash
+$ make stop
+```
+
 ### Important
 
 Be sure, that you are running Docker Desktop under Windows or Mac before you can run the make command.

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -4053,6 +4053,9 @@ async function addTextbox(textboxType) {
 }
 //ART TAB
 function uploadArt(imageSource, otherParams) {
+	if (!imageSource.includes('http')) {
+		imageSource = '/local_art/' + imageSource;
+	}
 	art.src = imageSource;
 	if (otherParams && otherParams == 'autoFit') {
 		art.onload = function() {

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -4053,7 +4053,7 @@ async function addTextbox(textboxType) {
 }
 //ART TAB
 function uploadArt(imageSource, otherParams) {
-	if (!imageSource.includes('http')) {
+	if (!imageSource.startsWith('data:image') && !imageSource.includes('http')) {
 		imageSource = '/local_art/' + imageSource;
 	}
 	art.src = imageSource;


### PR DESCRIPTION
- Fixed a bug where local art couldn't be used for card artwork (set symbol and watermark works, art tab was broken due to using a different function which didn't prepend /local_art/ directory).
- Made local_art directory a volume mount instead of a Dockerfile COPY operation, meaning new art can now be added to local_art directory without having to restart the process.
- Streamlined the Docker setup, adding a `make stop` command to stop+remove the container.