### PR TITLE
Find custom set symbols by set code

### DIFF
--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -4263,6 +4263,28 @@ function uploadSetSymbol(imageSource, otherParams) {
 		};
 	}
 }
+async function uploadLocalSetSymbol(imageName, otherParams) {
+	// Try different paths for local set symbols, prioritizing custom over official and svgs over pngs.
+	if (otherParams && otherParams == 'resetSetSymbol') {
+		setSymbol.onload = function() {
+			resetSetSymbol();
+			setSymbol.onload = setSymbolEdited;
+		};
+	}
+	const variations = [
+		`/img/setSymbols/custom/${imageName}.svg`,
+		`/img/setSymbols/custom/${imageName}.png`,
+		`/img/setSymbols/official/${imageName}.svg`,
+		`/img/setSymbols/official/${imageName}.png`,
+	]
+	for (url of variations) {
+		response = await fetch(url, {method: "HEAD"});
+		if (response.ok) {
+			setSymbol.src = url;
+			break;
+		}
+	}
+}
 function setSymbolEdited() {
 	card.setSymbolSource = setSymbol.src;
 	if (document.querySelector('#lockSetSymbolURL').checked) {
@@ -4306,9 +4328,9 @@ function fetchSetSymbol() {
 	}
 	var setRarity = document.querySelector('#set-symbol-rarity').value.toLowerCase().replace('uncommon', 'u').replace('common', 'c').replace('rare', 'r').replace('mythic', 'm') || 'c';
 	if (['sld', 'a22', 'a23', 'j22'].includes(setCode.toLowerCase())) {
-		uploadSetSymbol(fixUri(`/img/setSymbols/custom/${setCode.toLowerCase()}-${setRarity}.png`), 'resetSetSymbol');
+		uploadLocalSetSymbol(`${setCode.toLowerCase()}-${setRarity}`, 'resetSetSymbol');
 	} else if (['cc', 'logan', 'joe'].includes(setCode.toLowerCase())) {
-		uploadSetSymbol(fixUri(`/img/setSymbols/custom/${setCode.toLowerCase()}-${setRarity}.svg`), 'resetSetSymbol');
+		uploadLocalSetSymbol(`${setCode.toLowerCase()}-${setRarity}`, 'resetSetSymbol');
 	} else if (document.querySelector("#set-symbol-source").value == 'gatherer') {
 		if (setSymbolAliases.has(setCode.toLowerCase())) setCode = setSymbolAliases.get(setCode.toLowerCase());
 		uploadSetSymbol('http://gatherer.wizards.com/Handlers/Image.ashx?type=symbol&set=' + setCode + '&size=large&rarity=' + setRarity, 'resetSetSymbol');
@@ -4316,12 +4338,8 @@ function fetchSetSymbol() {
 		if (setSymbolAliases.has(setCode.toLowerCase())) setCode = setSymbolAliases.get(setCode.toLowerCase());
 		uploadSetSymbol('https://api.hexproof.io/symbols/set/' + setCode + '/' + setRarity, 'resetSetSymbol');
 	} else {
-		var extension = 'svg';
-		if (['moc', 'ltr', 'ltc', 'cmm', 'who', 'scd', 'woe', 'wot', 'woc', 'lci', 'lcc', 'mkm', 'mkc', 'otj', 'otc'].includes(setCode.toLowerCase())) {
-			extension = 'png';
-		}
 		if (setSymbolAliases.has(setCode.toLowerCase())) setCode = setSymbolAliases.get(setCode.toLowerCase());
-		uploadSetSymbol(fixUri(`/img/setSymbols/official/${setCode.toLowerCase()}-${setRarity}.` + extension), 'resetSetSymbol');
+		uploadLocalSetSymbol(`${setCode.toLowerCase()}-${setRarity}`, 'resetSetSymbol');
 	}
 }
 function lockSetSymbolCode() {


### PR DESCRIPTION
With this change, cardconjurer searches for set symbol images in both the custom and the official directories, preferring custom over official symbols and svgs over pngs. This way, people don't have to manually add their own set symbols with the "Via URL" field, they can just drop them into img/setSymbols/custom/ and use the set code and rarity fields like they'd do for official cards.

This also makes the weird hardcoding of specific set codes that have pngs instead of svgs or that are located in img/setSymbols/custom instead of img/setSymbols/official unnecessary.

Unfortunately this will log a 404 error message to console whenever we fail to find an image. I'm not aware of any reasonable way to avoid this--apparently you could register a service worker and have that handle the fetch but that seems like overkill to me.