### PR TITLE
Fix image url loading

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  "workbench.colorCustomizations": {
+    "commandCenter.border": "#15202b99",
+    "sash.hoverBorder": "#65c89b",
+    "statusBar.background": "#42b883",
+    "statusBar.foreground": "#15202b",
+    "statusBarItem.hoverBackground": "#359268",
+    "statusBarItem.remoteBackground": "#42b883",
+    "statusBarItem.remoteForeground": "#15202b",
+    "titleBar.activeBackground": "#42b883",
+    "titleBar.activeForeground": "#15202b",
+    "titleBar.inactiveBackground": "#42b88399",
+    "titleBar.inactiveForeground": "#15202b99"
+  },
+  "peacock.remoteColor": "#42b883"
+}

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -4097,7 +4097,7 @@ function uploadArt(imageSource, otherParams) {
 				art.onload = artEdited;
 			};
 		}
-	});
+	}, otherParams);
 }
 function artEdited() {
 	card.artSource = art.src;
@@ -5083,7 +5083,7 @@ async function loadCard(selectedCardKey) {
 		document.querySelector('#art-y').value = scaleY(card.artY) - scaleHeight(card.marginY);
 		document.querySelector('#art-zoom').value = card.artZoom * 100;
 		document.querySelector('#art-rotate').value = card.artRotate || 0;
-		uploadArt(card.artSource);
+		uploadArt(card.artSource, 'noproxy');
 		document.querySelector('#setSymbol-x').value = scaleX(card.setSymbolX) - scaleWidth(card.marginX);
 		document.querySelector('#setSymbol-y').value = scaleY(card.setSymbolY) - scaleHeight(card.marginY);
 		document.querySelector('#setSymbol-zoom').value = card.setSymbolZoom * 100;
@@ -5258,7 +5258,7 @@ function imageURL(url, destination, otherParams) {
 	// If an image URL does not have HTTP in it, assume it's a local file in the repo local_art directory.
 	if (!url.includes('http')) {
 		imageurl = '/local_art/' + url;
-	} else if (params.get('noproxy') != '') {
+	} else if (params.get('noproxy') != '' && (!otherParams || otherParams != 'noproxy')) {
 		//CORS PROXY LINKS
 		//Previously: https://cors.bridged.cc/
 		imageurl = 'https://corsproxy.io/?' + encodeURIComponent(url);

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -4089,13 +4089,15 @@ async function addTextbox(textboxType) {
 }
 //ART TAB
 function uploadArt(imageSource, otherParams) {
-	art.src = imageSource;
-	if (otherParams && otherParams == 'autoFit') {
-		art.onload = function() {
-			autoFitArt();
-			art.onload = artEdited;
-		};
-	}
+	imageURL(imageSource, (src) => {
+		art.src = src
+		if (otherParams && otherParams == 'autoFit') {
+			art.onload = function() {
+				autoFitArt();
+				art.onload = artEdited;
+			};
+		}
+	});
 }
 function artEdited() {
 	card.artSource = art.src;


### PR DESCRIPTION
The instructions in the readme mention if you add files to local_art, you can reference them by URL without adding the `local_art/` prefix.

Turns out that was broken. Fixed it by running the URL through one of the helper functions that either adds the local_art prefix or runs the URL through a proxy site to try and help with CORS issues.